### PR TITLE
Use LTS .NET Runtime installers

### DIFF
--- a/Installer/Install-Dotnet.ps1
+++ b/Installer/Install-Dotnet.ps1
@@ -21,9 +21,9 @@ foreach ($runtime in $runtimes)
 # Get .NET runtime installer URL
 $installerDownloadUrl = ""
 if ([Environment]::Is64BitOperatingSystem) {
-    $installerDownloadUrl = "https://download.visualstudio.microsoft.com/download/pr/3240250e-6fe0-4258-af69-85abef6c00de/e01ee0af6c65d894f4a02bdf6705ec7b/windowsdesktop-runtime-3.1.2-win-x64.exe"
+    $installerDownloadUrl = "https://download.visualstudio.microsoft.com/download/pr/5954c748-86a1-4823-9e7d-d35f6039317a/169e82cbf6fdeb678c5558c5d0a83834/windowsdesktop-runtime-3.1.3-win-x64.exe"
 } else {
-    $installerDownloadUrl = "https://download.visualstudio.microsoft.com/download/pr/b824906f-bd6e-4067-86a6-95c61620674d/cfcdab84a01cee94fdaa31271c3d4d47/windowsdesktop-runtime-3.1.2-win-x86.exe"
+    $installerDownloadUrl = "https://download.visualstudio.microsoft.com/download/pr/7cd5c874-5d11-4e72-81f0-4a005d956708/0eb310169770c893407169fc3abaac4f/windowsdesktop-runtime-3.1.3-win-x86.exe"
 }
 
 # Download .NET runtime to temp directory


### PR DESCRIPTION
Just changing the link to the 3.13 LTS .NET runtime installers

Literally my first time using git (we don't use it at work, so....) so please feel free to correct any errors.